### PR TITLE
Update Money.php

### DIFF
--- a/src/Money/Money.php
+++ b/src/Money/Money.php
@@ -193,7 +193,7 @@ class Money extends ValueObject
 
         $wholePart = substr((string)$this->amount, 0, -$fractionDigits) ?: '0';
 
-        $fractionalPart = str_pad(substr((string)$this->amount, -$fractionDigits), $fractionDigits, '0', STR_PAD_RIGHT);
+        $fractionalPart = str_pad(substr((string)$this->amount, -$fractionDigits), $fractionDigits, '0', STR_PAD_LEFT);
 
         return $wholePart . '.' . $fractionalPart;
     }


### PR DESCRIPTION
Money asString() function doesn't work for single-digit amount and adds 0 to the right side.

$money1 = (new Money(9, new Currency(Currency::AUD)))->asString();
// "0.90"

$money2 = (new Money(90, new Currency(Currency::AUD)))->asString();
// "0.90"

@TimeToogo can this change potentially break any other case?